### PR TITLE
Missing German translation string for Help.german.php (['help_contacts']...

### DIFF
--- a/german/Help.german.php
+++ b/german/Help.german.php
@@ -625,3 +625,15 @@ $txt['help_mediatag'] = '<h2>Was hat es mit dem [media] tag auf sich?</h2>
 		<li>Zeigt einen Titel unter dem Thumbnail (Wenn der Typ auf Link gesetzt wurde, wird der Titel anklickbar und leitet dich zur Seite der Datei.)</li>
 		<li>Eine beliebige Zeichenfolge ist hier möglich. Wenn die Zeichenfolge Leerzeichen oder Klammern enthalten sollte, achte darauf sie in "doppelte Anführungszeichen" zu setzen.</li>
 	</ul>';
+
+	$txt['help_contacts'] = 'Kontakte sind eine einfache Möglichkeit um deine Freunde in kategorisierte Listen zu organisieren. Diese Liste kann als partikuläre Privatssphäreneinstellung dienen. Du bestimmst genau, wer welche Aktion von dir sehen und verfolgen kann.
+	<br>Natürlich kannst du auch alle Personen in multiple Listen einsortieren.
+	<br><br>
+	Es gibt mehrere generelle Listentypen aus denen du auswählen kannst. Zusätzlich kannst du neue Listen erstellen, oder eine bereits existierende Liste umbenennen: es bleibt komplett dir überlassen.
+	<br>- Freunde: normalerweise die dir nahestehenden Personen.
+	<br>- Bekannte: Leute die du kennst, bei denen du aber unsicher bist, ob sie alles sehen sollen.
+	<br>- Kollegen: Arbeitskolegen, Leute mit denen du an einem Projekt arbeitest, etc.
+	<br>- Familie: Eltern, Geschwister, usw.
+	<br>- Gefolgt: jeder den du nicht persönlich kennst, aber denen du folgen möchtest.
+	<br>- Eingeschränkt: diese spezielle Liste beinhaltet Kontakte, denen du den Zugriff auf deine persönlichen Daten verweigern möchtest. Auch wenn diese Personen in einer anderen Liste stehen. Du kannst natürlich sehen, wer Teil dieser Liste ist.';
+


### PR DESCRIPTION
...).

Dunno how this was vanished in translation process.

Signed-off-by: Sven Rissmann creaworld-media@gmx.de
