### PR TITLE
Update Notifications.german.php

### DIFF
--- a/german/Notifications.german.php
+++ b/german/Notifications.german.php
@@ -5,6 +5,7 @@ $txt['notifications'] = 'Benachrichtigungen';
 $txt['notifications_short_unread'] = 'Ungelesen';
 $txt['notifications_short_latest'] = 'Neueste';
 $txt['notifications_short_all'] = 'Alle ansehen';
+$txt['notifications_short_mark_as_read'] = 'Gelesen!';
 $txt['notifications_short_settings'] = 'Einstellungen';
 $txt['notifications_short_unread_pms'] = 'Ungelesen';
 $txt['notifications_short_inbox'] = 'Posteingang';


### PR DESCRIPTION
This is not an exact translation but a direct translation ("Als gelesen markieren") does look bad, feels bad and is just too long (notification header gets splitted into two lines). "Gelesen!" is more like "Read it!" or "Noticed it!". Maybe not too formal, but if someone doesn't like it, he/she can still change it.